### PR TITLE
adding option to disable public IP allocation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -51,6 +51,8 @@ system so it can run Chef Client with a Chef Server. The main assumption is a ba
 intended for Chef Client systems that talk to a Chef server.  By default the server is bootstrapped using the {ubuntu10.04-gems}[https://github.com/opscode/chef/bl
 ob/master/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb] template.  This can be overridden using the <tt>-d</tt> or <tt>--template-file</tt> command options.
 
+By default, new servers are allocated a public IP address mapping to the CloudStack private IP address. If you do not want this behavior, pass the <tt>--no-public-ip</tt> option.
+
 ==== Port forwarding rules for virtual networks
 The <tt>--port-rules</tt> option takes a comma separated list of port forwarding rules. These rules are created on the
 virtual public ip address of the server. Note that this option only applies to servers using a virtual network; it is

--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -65,6 +65,12 @@ module KnifeCloudstack
            :proc => lambda { |n| n.split(/[\s,]+/) },
            :default => []
 
+    option :public_ip,
+           :long => "--[no-]public-ip",
+           :description => "Allocate a public IP for this server",
+           :boolean => true,
+           :default => true
+
     option :chef_node_name,
            :short => "-N NAME",
            :long => "--node-name NAME",
@@ -228,15 +234,15 @@ module KnifeCloudstack
 
     def find_or_create_public_ip(server, connection)
       nic = connection.get_server_default_nic(server) || {}
-      if nic['type'] == 'Virtual' then
+      #puts "#{ui.color("Not allocating public IP for server", :red)}" unless config[:public_ip]
+      if (config[:public_ip] == false) || (nic['type'] != 'Virtual') then
+        nic['ipaddress']
+      else
         # create ip address, ssh forwarding rule and optional forwarding rules
         ip_address = connection.associate_ip_address(server['zoneid'])
         ssh_rule = connection.create_port_forwarding_rule(ip_address['id'], "22", "TCP", "22", server['id'])
         create_port_forwarding_rules(ip_address['id'], server['id'], connection)
         ssh_rule['ipaddress']
-      else
-        # otherwise return the nic ip address
-        nic['ipaddress']
       end
     end
 


### PR DESCRIPTION
Provides a method to disable the allocation of a public IP mapping for a new instance.
