### PR TITLE
no longer sending networkids if --no-public-ip option is used

### DIFF
--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -182,7 +182,8 @@ module KnifeCloudstack
           locate_config_value(:cloudstack_service),
           locate_config_value(:cloudstack_template),
           locate_config_value(:cloudstack_zone),
-          locate_config_value(:cloudstack_networks)
+          locate_config_value(:cloudstack_networks),
+          locate_config_value(:public_ip)
       )
 
       public_ip = find_or_create_public_ip(server, connection)

--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -109,7 +109,7 @@ module CloudstackClient
     ##
     # Deploys a new server using the specified parameters.
 
-    def create_server(host_name, service_name, template_name, zone_name=nil, network_names=[])
+    def create_server(host_name, service_name, template_name, zone_name=nil, network_names=[], public_ip=nil)
 
       if host_name then
         if get_server(host_name) then
@@ -161,9 +161,10 @@ module CloudstackClient
           'command' => 'deployVirtualMachine',
           'serviceOfferingId' => service['id'],
           'templateId' => template['id'],
-          'zoneId' => zone['id'],
-          'networkids' => network_ids.join(',')
+          'zoneId' => zone['id']
       }
+      params.merge!('networkids' => network_ids.join(',')) if public_ip
+      
       params['name'] = host_name if host_name
 
       json = send_async_request(params)


### PR DESCRIPTION
When the --no-public-ip option is used, the "networkids" param is still sent with the API request to CS which causes a "Can't specify network Ids in Basic zone" error. This patch will prevent this parameter being sent if --no-public-ip is set. Needs to be tested with advanced networking.
