### PR TITLE
Helper module. Fix SSL support

### DIFF
--- a/lib/chef/knife/cs_hosts.rb
+++ b/lib/chef/knife/cs_hosts.rb
@@ -51,13 +51,13 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
-    def run
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
 
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key)
-      )
+    def run
 
       host_list = [
           ui.color('#Public IP', :bold),

--- a/lib/chef/knife/cs_network_list.rb
+++ b/lib/chef/knife/cs_network_list.rb
@@ -48,13 +48,13 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
-    def run
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
 
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key)
-      )
+    def run
 
       network_list = [
           ui.color('Name', :bold),

--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -206,16 +206,12 @@ module KnifeCloudstack
       :long => '--fqdn',
       :description => "FQDN which Kerberos Understands (only for Windows Servers)"
 
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
 
-    def connection
-      @connection ||= CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key),
-          locate_config_value(:cloudstack_project),
-          locate_config_value(:use_http_ssl)
-      )
-    end
 
     def run
       Chef::Log.debug("Validate hostname and options")

--- a/lib/chef/knife/cs_server_delete.rb
+++ b/lib/chef/knife/cs_server_delete.rb
@@ -57,10 +57,10 @@ module KnifeCloudstack
            :default => nil
 
     option :use_http_ssl,
-          :long => '--[no-]use-http-ssl',
-          :description => 'Support HTTPS',
-          :boolean => true,
-          :default => true
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true
 
     def run
 

--- a/lib/chef/knife/cs_server_list.rb
+++ b/lib/chef/knife/cs_server_list.rb
@@ -56,21 +56,13 @@ module KnifeCloudstack
            :default => nil
 
     option :use_http_ssl,
-          :long => '--[no-]use-http-ssl',
-          :description => 'Support HTTPS',
-          :boolean => true,
-          :default => true     
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
     def run
 
       $stdout.sync = true
-
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key),
-          locate_config_value(:cloudstack_project),
-          locate_config_value(:use_http_ssl)
-      )
 
       server_list = [
           ui.color('Name', :bold),

--- a/lib/chef/knife/cs_server_reboot.rb
+++ b/lib/chef/knife/cs_server_reboot.rb
@@ -50,6 +50,12 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
+
     def run
 
       @name_args.each do |hostname|
@@ -78,17 +84,6 @@ module KnifeCloudstack
         ui.msg("Rebooted server #{hostname}")
       end
 
-    end
-
-    def connection
-      unless @connection
-        @connection = CloudstackClient::Connection.new(
-            locate_config_value(:cloudstack_url),
-            locate_config_value(:cloudstack_api_key),
-            locate_config_value(:cloudstack_secret_key)
-        )
-      end
-      @connection
     end
 
     def msg(label, value)

--- a/lib/chef/knife/cs_server_start.rb
+++ b/lib/chef/knife/cs_server_start.rb
@@ -50,6 +50,12 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
+
     def run
 
       @name_args.each do |hostname|
@@ -78,17 +84,6 @@ module KnifeCloudstack
         ui.msg("Started server #{hostname}")
       end
 
-    end
-
-    def connection
-      unless @connection
-        @connection = CloudstackClient::Connection.new(
-            locate_config_value(:cloudstack_url),
-            locate_config_value(:cloudstack_api_key),
-            locate_config_value(:cloudstack_secret_key)
-        )
-      end
-      @connection
     end
 
     def msg(label, value)

--- a/lib/chef/knife/cs_server_stop.rb
+++ b/lib/chef/knife/cs_server_stop.rb
@@ -55,6 +55,12 @@ module KnifeCloudstack
            :description => "Force stop the VM. The caller knows the VM is stopped.",
            :boolean => true
 
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
+
     def run
 
       @name_args.each do |hostname|
@@ -89,17 +95,6 @@ module KnifeCloudstack
         ui.msg("Stopped server #{hostname}")
       end
 
-    end
-
-    def connection
-      unless @connection
-        @connection = CloudstackClient::Connection.new(
-            locate_config_value(:cloudstack_url),
-            locate_config_value(:cloudstack_api_key),
-            locate_config_value(:cloudstack_secret_key)
-        )
-      end
-      @connection
     end
 
     def msg(label, value)

--- a/lib/chef/knife/cs_service_list.rb
+++ b/lib/chef/knife/cs_service_list.rb
@@ -50,13 +50,13 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
-    def run
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
 
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key)
-      )
+    def run
 
       service_list = [
           ui.color('Name', :bold),

--- a/lib/chef/knife/cs_stack_create.rb
+++ b/lib/chef/knife/cs_stack_create.rb
@@ -74,6 +74,12 @@ module KnifeCloudstack
            :long => "--identity-file IDENTITY_FILE",
            :description => "The SSH identity file used for authentication"
 
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
+
     def run
       file_path = File.expand_path(@name_args.first)
       unless File.exist?(file_path) then
@@ -86,16 +92,6 @@ module KnifeCloudstack
       create_stack stack
 
       #puts "Stack: #{stack.inspect}"
-    end
-
-    def connection
-      if (!@connection) then
-        url = locate_config_value(:cloudstack_url)
-        api_key = locate_config_value(:cloudstack_api_key)
-        secret_key = locate_config_value(:cloudstack_secret_key)
-        @connection = CloudstackClient::Connection.new(url, api_key, secret_key)
-      end
-      @connection
     end
 
     def create_stack(stack)

--- a/lib/chef/knife/cs_stack_delete.rb
+++ b/lib/chef/knife/cs_stack_delete.rb
@@ -48,6 +48,12 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true     
+
     def run
       file_path = File.expand_path(@name_args.first)
       unless File.exist?(file_path) then

--- a/lib/chef/knife/cs_template_list.rb
+++ b/lib/chef/knife/cs_template_list.rb
@@ -64,20 +64,12 @@ module KnifeCloudstack
            :default => nil
 
     option :use_http_ssl,
-          :long => '--[no-]use-http-ssl',
-          :description => 'Support HTTPS',
-          :boolean => true,
-          :default => true       
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true       
 
     def run
-
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key),
-          locate_config_value(:cloudstack_project),
-          locate_config_value(:use_http_ssl)
-      )
 
       template_list = [
           ui.color('Name', :bold),

--- a/lib/chef/knife/cs_zone_list.rb
+++ b/lib/chef/knife/cs_zone_list.rb
@@ -48,13 +48,13 @@ module KnifeCloudstack
            :description => "Your CloudStack secret key",
            :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
 
-    def run
+    option :use_http_ssl,
+           :long => '--[no-]use-http-ssl',
+           :description => 'Support HTTPS',
+           :boolean => true,
+           :default => true       
 
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key)
-      )
+    def run
 
       zone_list = [
           ui.color('Name', :bold),

--- a/lib/knife-cloudstack/helpers.rb
+++ b/lib/knife-cloudstack/helpers.rb
@@ -4,5 +4,15 @@ module KnifeCloudstack
       key = key.to_sym
       Chef::Config[:knife][key].nil? ? config[key] : Chef::Config[:knife][key]
     end
+
+    def connection
+      @connection ||= CloudstackClient::Connection.new(
+        locate_config_value(:cloudstack_url),
+        locate_config_value(:cloudstack_api_key),
+        locate_config_value(:cloudstack_secret_key),
+        locate_config_value(:cloudstack_project),
+        locate_config_value(:use_http_ssl)
+      )
+    end
   end
 end


### PR DESCRIPTION
Provides a helper module to provide common methods and reduce duplication. Also provides consistent SSL support across all knife commands.
