### PR TITLE
Bugfix - list_public_ip_addresses() may return Nil

### DIFF
--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -97,7 +97,10 @@ module CloudstackClient
         return ssh_rule['ipaddress']
       end
       #check for static NAT
-      ip_addr = list_public_ip_addresses.find {|v| v['virtualmachineid'] == server['id']}
+      ip_list = list_public_ip_addresses()
+      if ip_list
+        ip_addr = ip_list.find {|v| v['virtualmachineid'] == server['id']}
+      end
       if ip_addr
         return ip_addr['ipaddress']
       end


### PR DESCRIPTION
Bugfix - list_public_ip_addresses() may return Nil what results in:
knife cs server list -VV
/opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/knife-cloudstack-0.0.13/lib/knife-cloudstack/connection.rb:84:in `get_server_public_ip': undefined method`find' for nil:NilClass (NoMethodError)
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/knife-cloudstack-0.0.13/lib/chef/knife/cs_server_list.rb:92:in `block in run'
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/knife-cloudstack-0.0.13/lib/chef/knife/cs_server_list.rb:84:in`each'
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/knife-cloudstack-0.0.13/lib/chef/knife/cs_server_list.rb:84:in `run'
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/knife.rb:460:in`run_with_pretty_exceptions'
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/knife.rb:173:in `run'
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application/knife.rb:123:in`run'
        from /opt/chef-server/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/bin/knife:25:in `<top (required)>'
        from /opt/chef-server/embedded/bin/knife:23:in`load'
        from /opt/chef-server/embedded/bin/knife:23:in `<main>'
