### PR TITLE
no_bootstrap code was working backwards

### DIFF
--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -152,7 +152,7 @@ module KnifeCloudstack
            :boolean => true,
            :default => false
 
-    option :no_bootstrap,
+    option :bootstrap,
            :long => "--[no-]bootstrap",
            :description => "Disable Chef bootstrap",
            :boolean => true,
@@ -237,7 +237,7 @@ module KnifeCloudstack
       puts "#{ui.color('Password', :cyan)}: #{server['password']}" if locate_config_value(:cloudstack_password)
       puts "#{ui.color('Public IP', :cyan)}: #{public_ip}"
 
-      return if config[:no_bootstrap]
+      return unless config[:bootstrap]
 
       if @bootstrap_protocol == 'ssh'
         print "\n#{ui.color("Waiting for sshd", :magenta)}"
@@ -288,7 +288,7 @@ module KnifeCloudstack
         ui.error "Cloudstack service offering not specified"
         exit 1
       end
-      unless config[:no_bootstrap]
+      if config[:bootstrap]
         if locate_config_value(:bootstrap_protocol) == 'ssh'
           identity_file = locate_config_value :identity_file
           ssh_user = locate_config_value :ssh_user


### PR DESCRIPTION
This should address #3
--no-bootstrap will skip bootstrapping and the check for credentials
--bootstrap (or omitting it) will check if credentials are given and do a bootstrap.

<snip>
[frank@tom WindowsBaseImage]$ knife cs server create 'fb2013040201' --service 'cust-large-ha' --template 'MotherWindows2008R2x64EEv1' --defaults --disable-editing --no-bootstrap --no-public-ip --cloudstack-project 'windowsbase'  -V -V
DEBUG: Validate hostname and options
INFO: Creating instance with
        service : cust-large-ha
        template : MotherWindows2008R2x64EEv1
        zone :
        project: windowsbase
        network: []

Waiting for Server to be created......

Name: fb2013040201
Public IP: 10.1.1.233
[frank@tom WindowsBaseImage]$
</snip>
