### PR TITLE
bootstrap problem

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,8 +50,9 @@ This plugin provides the following Knife subcommands.  Specific command options 
 
 Provisions a new server in CloudStack and then performs a Chef bootstrap (using the SSH protocol).  The goal of the bootstrap is to get Chef installed on the target
 system so it can run Chef Client with a Chef Server. The main assumption is a baseline OS installation exists (provided by the provisioning). It is primarily
-intended for Chef Client systems that talk to a Chef server.  By default the server is bootstrapped using the {ubuntu10.04-gems}[https://github.com/opscode/chef/bl
-ob/master/chef/lib/chef/knife/bootstrap/ubuntu10.04-gems.erb] template.  This can be overridden using the <tt>-d</tt> or <tt>--template-file</tt> command options.
+intended for Chef Client systems that talk to a Chef server.  By default the server is bootstrapped using the 'chef-full' template (default bootstrap option for knife,
+Ref. http://docs.opscode.com/knife_bootstrap.html). This can be overridden using the <tt>-d</tt> or <tt>--template-file</tt> command options.
+Bootstrap can be disabled using <tt>--no-bootstrap</tt> option, in order to provide a VM without chef-client installed.
 
 By default, new servers are allocated a public IP address mapping to the CloudStack private IP address. If you do not want this behavior, pass the <tt>--no-public-ip</tt> option.
 

--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -156,11 +156,11 @@ module KnifeCloudstack
            :boolean => true,
            :default => false
 
-    option :bootstrap,
-           :long => "--[no-]bootstrap",
+    option :no_bootstrap,
+           :long => "--no-bootstrap",
            :description => "Disable Chef bootstrap",
            :boolean => true,
-           :default => true
+           :default => false
 
     option :port_rules,
            :short => "-p PORT_RULES",
@@ -233,7 +233,7 @@ module KnifeCloudstack
       puts "#{ui.color('Password', :cyan)}: #{server['password']}" if locate_config_value(:cloudstack_password)
       puts "#{ui.color('Public IP', :cyan)}: #{public_ip}"
 
-      return unless config[:bootstrap]
+      return if config[:no_bootstrap]
 
       if @bootstrap_protocol == 'ssh'
         print "\n#{ui.color("Waiting for sshd", :magenta)}"
@@ -284,7 +284,7 @@ module KnifeCloudstack
         ui.error "Cloudstack service offering not specified"
         exit 1
       end
-      if config[:bootstrap]
+      unless config[:no_bootstrap]
         if locate_config_value(:bootstrap_protocol) == 'ssh'
           identity_file = locate_config_value :identity_file
           ssh_user = locate_config_value :ssh_user


### PR DESCRIPTION
In cs_server_create.rb fixed --no-bootstrap option that wasn't working (bootstrap was executed anyway).
Removed --bootstrap option: it is the default and it is not necessary to specify it.

Corrected README.rdoc to explain --no-bootstrap option.
Corrected README.rdoc to explain that bootstrap is execurted using the 'chef-full' template.
