### PR TITLE
Added '--fw-rules' option to implement createFirewallRule API

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -69,6 +69,14 @@ single number when the public and private ports are the same. For example, a rul
 private port 25 can be stated as simply <tt>25</tt>. A list of such rules for a webserver might look like
 <tt>80,443</tt>.
 
+==== Create Firewall Rule for given ip address
+The <tt>-f, --fw-rules</tt> option takes a comma separated list of firewall rules which are applied to the public ip address assigned to the current server.
+
+Firewall rules have the syntax <tt>START_PORT[:END_PORT[:PROTOCOL[:CIDR_LIST]]]</tt>. <tt>END_PORT</tt>, <tt>PROTOCOL</tt> and <tt>CIDR_LIST</tt> are optional.
+The default value of <tt>END_PORT</tt> is <tt>START_PORT</tt>, the default <tt>PROTOCOL</tt> is 'TCP' and the default <tt>CIDR_LIST</tt> is '0.0.0.0/0'.
+For example, a rule to open firewall for port 80 to everyone would look like <tt>80:80:TCP:0.0.0.0/0</tt>.
+In this case ,it could even be shortened to <tt>80</tt>.
+
 === knife cs server delete
 
 Deletes an existing server in the currently configured CloudStack account.  <b>PLEASE NOTE</b> - this does not delete

--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -622,6 +622,17 @@ module CloudstackClient
       send_async_request(params)
     end
 
+    def create_firewall_rule(ipaddress_id, protocol, start_port, end_port, cidr_list)
+      params = {
+        'command' => 'createFirewallRule',
+        'ipaddressId' => ipaddress_id,
+        'protocol' => protocol,
+        'startport' =>  start_port,
+        'endport' => end_port,
+        'cidrlist' => cidr_list
+      }
+      send_async_request(params)
+    end
 
     ##
     # Disassociates an ip address from the account.


### PR DESCRIPTION
This option implements createFirewallRule API when called with <tt>knife cs server create</tt> command.

Ref.
http://cloudstack.apache.org/docs/api/apidocs-4.0.0/root_admin/createFirewallRule.html

For us it is very useful because we need to automate creation of chef nodes on cloudstack with static_nat enabled and we would like to set firewall policies for static public ip during VM creation.
