### PR TITLE
adding the base_options and removing duplicate options / functions

### DIFF
--- a/lib/chef/knife/cs_server_delete.rb
+++ b/lib/chef/knife/cs_server_delete.rb
@@ -1,6 +1,8 @@
 #
 # Author:: Ryan Holmes (<rholmes@edmunds.com>)
+# Author:: Sander Botman (<sbotman@schubergphilis.com>)
 # Copyright:: Copyright (c) 2011 Edmunds, Inc.
+# Copyright:: Copyright (c) 2013 Sander Botman.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +19,12 @@
 #
 
 require 'chef/knife'
+require 'chef/knife/cs_base'
 
 module KnifeCloudstack
   class CsServerDelete < Chef::Knife
+
+    include Chef::Knife::KnifeCloudstackBase
 
     deps do
       require 'knife-cloudstack/connection'
@@ -28,38 +33,8 @@ module KnifeCloudstack
 
     banner "knife cs server delete SERVER_NAME [SERVER_NAME ...] (options)"
 
-    option :cloudstack_url,
-           :short => "-U URL",
-           :long => "--cloudstack-url URL",
-           :description => "The CloudStack endpoint URL",
-           :proc => Proc.new { |url| Chef::Config[:knife][:cloudstack_url] = url }
-
-    option :cloudstack_api_key,
-           :short => "-A KEY",
-           :long => "--cloudstack-api-key KEY",
-           :description => "Your CloudStack API key",
-           :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_api_key] = key }
-
-    option :cloudstack_secret_key,
-           :short => "-K SECRET",
-           :long => "--cloudstack-secret-key SECRET",
-           :description => "Your CloudStack secret key",
-           :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
-
-    option :cloudstack_project,
-           :short => "-P PROJECT_NAME",
-           :long => '--cloudstack-project PROJECT_NAME',
-           :description => "Cloudstack Project in which to create server",
-           :proc => Proc.new { |v| Chef::Config[:knife][:cloudstack_project] = v },
-           :default => nil
-
-    option :use_http_ssl,
-          :long => '--[no-]use-http-ssl',
-          :description => 'Support HTTPS',
-          :boolean => true,
-          :default => true
-
     def run
+      validate_base_options
 
       @name_args.each do |hostname|
         server = connection.get_server(hostname)
@@ -74,16 +49,26 @@ module KnifeCloudstack
           next
         end
 
-        puts "\n"
-        msg("Name", server['name'])
-        msg("Public IP", connection.get_server_public_ip(server) || '?')
-        msg("Service", server['serviceofferingname'])
-        msg("Template", server['templatename'])
-        msg("Domain", server['domain'])
-        msg("Zone", server['zonename'])
-        msg("State", server['state'])
+        object_field = []
+        object_field << ui.color("Name:", :cyan)
+        object_field << server['name'].to_s
+        object_field << ui.color("Public IP:", :cyan)
+        object_field << (connection.get_server_public_ip(server) || '?')
+        object_field << ui.color("Service:", :cyan)
+        object_field << server['serviceofferingname'].to_s
+        object_field << ui.color("Template:", :cyan)
+        object_field << server['templatename']
+        object_field << ui.color("Domain:", :cyan)
+        object_field << server['domain']
+        object_field << ui.color("Zone:", :cyan)
+        object_field << server['zonename']
+        object_field << ui.color("State:", :cyan)
+        object_field << server['state']
 
         puts "\n"
+        puts ui.list(object_field, :uneven_columns_across, 2)
+        puts "\n"
+
         ui.confirm("Do you really want to delete this server")
 
         print "#{ui.color("Waiting for deletion", :magenta)}"
@@ -133,30 +118,6 @@ module KnifeCloudstack
 
       node.destroy
       ui.msg "Deleted node #{name}"
-    end
-
-    def connection
-      unless @connection
-        @connection = CloudstackClient::Connection.new(
-            locate_config_value(:cloudstack_url),
-            locate_config_value(:cloudstack_api_key),
-            locate_config_value(:cloudstack_secret_key),
-            locate_config_value(:cloudstack_project),
-            locate_config_value(:use_http_ssl)
-        )
-      end
-      @connection
-    end
-
-    def msg(label, value)
-      if value && !value.empty?
-        puts "#{ui.color(label, :cyan)}: #{value}"
-      end
-    end
-
-    def locate_config_value(key)
-      key = key.to_sym
-      Chef::Config[:knife][key] || config[key]
     end
 
   end


### PR DESCRIPTION
Because there were also some problems with displaying help on this command, I thought it would be best to cleanup the code and include the base options so that duplicated options and functions could be removed. And this is fixing the --help output also of course...
