### PR TITLE
Updated hosts command to respect no-ssl flag.

### DIFF
--- a/lib/chef/knife/cs_hosts.rb
+++ b/lib/chef/knife/cs_hosts.rb
@@ -17,44 +17,26 @@
 # limitations under the License.
 #
 
+require 'chef/knife/cs_base'
+require 'chef/knife/cs_baselist'
+
 module KnifeCloudstack
   class CsHosts < Chef::Knife
 
     MEGABYTES = 1024 * 1024
 
+    include Chef::Knife::KnifeCloudstackBase
+    include Chef::Knife::KnifeCloudstackBaseList
+
     deps do
       require 'knife-cloudstack/connection'
-      require 'chef/knife'
       Chef::Knife.load_deps
     end
 
     banner "knife cs hosts"
 
-    option :cloudstack_url,
-           :short => "-U URL",
-           :long => "--cloudstack-url URL",
-           :description => "The CloudStack endpoint URL",
-           :proc => Proc.new { |url| Chef::Config[:knife][:cloudstack_url] = url }
-
-    option :cloudstack_api_key,
-           :short => "-A KEY",
-           :long => "--cloudstack-api-key KEY",
-           :description => "Your CloudStack API key",
-           :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_api_key] = key }
-
-    option :cloudstack_secret_key,
-           :short => "-K SECRET",
-           :long => "--cloudstack-secret-key SECRET",
-           :description => "Your CloudStack secret key",
-           :proc => Proc.new { |key| Chef::Config[:knife][:cloudstack_secret_key] = key }
-
     def run
-
-      connection = CloudstackClient::Connection.new(
-          locate_config_value(:cloudstack_url),
-          locate_config_value(:cloudstack_api_key),
-          locate_config_value(:cloudstack_secret_key)
-      )
+      validate_base_options
 
       host_list = [
           ui.color('#Public IP', :bold),
@@ -72,12 +54,5 @@ module KnifeCloudstack
       puts ui.list(host_list, :columns_across, 3)
 
     end
-
-
-    def locate_config_value(key)
-      key = key.to_sym
-      Chef::Config[:knife][key] || config[key]
-    end
-
   end
 end


### PR DESCRIPTION
There was a bug where if you had set the no-http-ssl flag,
knife cs hosts would fail, since it was not respecting the flag.
