### PR TITLE
Add possibility to allow ICMP traffic inside firewall-rules

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -97,10 +97,9 @@ single number when the start and end ports are the same. For example, a rule to 
 ==== Create Firewall Rule for given ip address
 The <tt>-f, --fw-rules</tt> option takes a comma separated list of firewall rules which are applied to the public ip address assigned to the current server.
 
-Firewall rules have the syntax <tt>START_PORT[:END_PORT[:PROTOCOL[:CIDR_LIST]]]</tt>. <tt>END_PORT</tt>, <tt>PROTOCOL</tt> and <tt>CIDR_LIST</tt> are optional.
-The default value of <tt>END_PORT</tt> is <tt>START_PORT</tt>, the default <tt>PROTOCOL</tt> is 'TCP' and the default <tt>CIDR_LIST</tt> is '0.0.0.0/0'.
-For example, a rule to open firewall for port 80 to everyone would look like <tt>80:80:TCP:0.0.0.0/0</tt>.
-In this case ,it could even be shortened to <tt>80</tt>.
+Firewall rules have the syntax <tt>PROTOCOL[:CIDR_LIST[:START_PORT[:END_PORT]]]</tt>. <tt>START_PORT</tt> and <tt>END_PORT</tt> must not be specified when <tt>PROTOCOL</tt> is <tt>ICMP</tt>, <tt>CIDR_LIST</tt> is always optional.
+The default value of <tt>END_PORT</tt> is <tt>START_PORT</tt>, the default <tt>CIDR_LIST</tt> is '0.0.0.0/0'.
+For example, a rule to open firewall for port 80 to everyone would look like <tt>TCP::80</tt> and a rule to open ICMP to internal network would look like <tt>ICMP:10.0.0.0/8</tt>.
 
 === knife cs server delete
 

--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -622,15 +622,26 @@ module CloudstackClient
       send_async_request(params)
     end
 
-    def create_firewall_rule(ipaddress_id, protocol, start_port, end_port, cidr_list)
-      params = {
-        'command' => 'createFirewallRule',
-        'ipaddressId' => ipaddress_id,
-        'protocol' => protocol,
-        'startport' =>  start_port,
-        'endport' => end_port,
-        'cidrlist' => cidr_list
-      }
+    def create_firewall_rule(ipaddress_id, protocol, param3, param4, cidr_list)
+      if protocol == "ICMP"
+        params = {
+          'command' => 'createFirewallRule',
+          'ipaddressId' => ipaddress_id,
+          'protocol' => protocol,
+          'icmptype' =>  param3,
+          'icmpcode' => param4,
+          'cidrlist' => cidr_list
+        }
+      else
+        params = {
+          'command' => 'createFirewallRule',
+          'ipaddressId' => ipaddress_id,
+          'protocol' => protocol,
+          'startport' =>  param3,
+          'endport' => param4,
+          'cidrlist' => cidr_list
+        }
+      end
       send_async_request(params)
     end
 


### PR DESCRIPTION
VMs cannot answer to 'ping' by default, because firewall rule for ICMP traffic is not set.
With this pull request I modified **--fw-rules** option in order to be able to set ICMP traffic firewall rule also.
Now choosing **protocol** is mandatory, while **start** and **end** port must be used only with tcp and udp protocols.
If ICMP is enabled, by design only ECHO, ECHO REPLY and DESTINATION UNREACHABLE (only codes 0,1) types are allowed:
- http://www.iana.org/assignments/icmp-parameters/icmp-parameters.xml
