### PR TITLE
Support for SSH Key Pairs

### DIFF
--- a/lib/chef/knife/cs_keypair_create.rb
+++ b/lib/chef/knife/cs_keypair_create.rb
@@ -1,0 +1,77 @@
+# Copyright:: Copyright (c) 2013 
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/cs_base'
+
+module KnifeCloudstack
+  class CsKeypairCreate < Chef::Knife
+
+    include Chef::Knife::KnifeCloudstackBase
+
+    deps do
+      require 'knife-cloudstack/connection'
+      Chef::Knife.load_deps
+    end
+
+    banner "knife cs keypair create (options)"
+
+    option :name,
+           :long => "--name NAME",
+           :description => "Specify the ssh keypair name",
+           :required => true
+
+    def run
+      validate_base_options
+
+      Chef::Log.debug("Validate keypair name")
+      if  locate_config_value(:name)
+        keypairname = locate_config_value(:name)
+      else
+          ui.error "Invalid keypairname. Please specify a name for the keypair"
+          exit 1
+      end
+
+      print "#{ui.color("Creating SSH Keypair: #{keypairname}", :magenta)}\n"
+
+      params = {
+        'command' => 'createSSHKeyPair',
+        'name' => keypairname,
+      }
+
+      json = connection.send_request(params)
+
+      if ! json then
+        ui.error("Unable to create SSH Keypair")
+	exit 1
+      end
+
+      object_fields = []
+      object_fields << ui.color("Name:", :cyan)
+      object_fields << json['keypair']['name'].to_s
+      object_fields << ui.color("Fingerprint:", :cyan)
+      object_fields << json['keypair']['fingerprint'].to_s
+      object_fields << ui.color("PrivateKey:", :cyan)
+      object_fields << json['keypair']['privateKey'].to_s
+
+      puts "\n"
+      puts ui.list(object_fields, :uneven_columns_across, 2)
+      puts "\n"
+      
+      return
+    end
+
+  end # class
+end

--- a/lib/chef/knife/cs_keypair_delete.rb
+++ b/lib/chef/knife/cs_keypair_delete.rb
@@ -1,0 +1,75 @@
+# Copyright:: Copyright (c) 2013 
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/cs_base'
+
+module KnifeCloudstack
+  class CsKeypairDelete < Chef::Knife
+
+    include Chef::Knife::KnifeCloudstackBase
+
+    deps do
+      require 'knife-cloudstack/connection'
+      Chef::Knife.load_deps
+    end
+
+    banner "knife cs keypair delete (options)"
+
+    option :name,
+           :long => "--name NAME",
+           :description => "Specify the ssh keypair name",
+           :required => true
+
+    def run
+      validate_base_options
+
+      Chef::Log.debug("Validate keypair name")
+      if  locate_config_value(:name)
+        keypairname = locate_config_value(:name)
+      else
+          ui.error "Invalid keypairname. Please specify a name for the keypair"
+          exit 1
+      end
+
+      print "#{ui.color("Deleting the SSH Keypair: #{keypairname}", :magenta)}\n"
+
+      params = {
+        'command' => 'deleteSSHKeyPair',
+        'name' => keypairname,
+      }
+
+      json = connection.send_request(params)
+
+      if ! json then
+        ui.error("Unable to delete SSH Keypair")
+	exit 1
+      end
+
+      object_fields = []
+      object_fields << ui.color("Info:", :cyan)
+      object_fields << json['displaytext'].to_s
+      object_fields << ui.color("Success:", :cyan)
+      object_fields << json['success'].to_s
+
+      puts "\n"
+      puts ui.list(object_fields, :uneven_columns_across, 2)
+      puts "\n"
+      
+      return
+    end
+
+  end # class
+end

--- a/lib/chef/knife/cs_keypair_list.rb
+++ b/lib/chef/knife/cs_keypair_list.rb
@@ -1,0 +1,96 @@
+# Copyright:: Copyright (c) 2011 Edmunds, Inc.
+# Copyright:: Copyright (c) 2013 Sander Botman.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/cs_base'
+require 'chef/knife/cs_baselist'
+
+module KnifeCloudstack
+  class CsKeypairList < Chef::Knife
+
+    include Chef::Knife::KnifeCloudstackBase
+    include Chef::Knife::KnifeCloudstackBaseList
+
+    deps do
+      require 'chef/knife'
+      require 'knife-cloudstack/connection'
+      Chef::Knife.load_deps
+    end
+
+    banner "knife cs keypair list (options)"
+
+    option :name,
+           :long => "--name NAME",
+           :description => "Specify security group to list"
+
+    option :keyword,
+           :long => "--keyword NAME",
+           :description => "Specify part of servicename to list"
+
+    option :index,
+           :long => "--index",
+           :description => "Add index numbers to the output",
+           :boolean => true
+
+    def run
+      validate_base_options
+	
+      object_list = []
+      object_list << ui.color('Index', :bold) if locate_config_value(:index)
+
+      if locate_config_value(:fields)
+        locate_config_value(:fields).split(',').each { |n| object_list << ui.color(("#{n}").strip, :bold) }
+      else
+        [
+          ui.color('Name', :bold),
+          ui.color('Fingerprint', :bold),
+        ].each { |field| object_list << field }
+      end
+
+      columns = object_list.count
+      object_list = [] if locate_config_value(:noheader)
+
+      connection_result = connection.list_object(
+        "listSSHKeyPairs",
+        "sshkeypair",
+        locate_config_value(:filter),
+        false,
+        locate_config_value(:keyword),
+        locate_config_value(:name)
+      )
+
+      output_format(connection_result)
+ 
+      index_num = 0
+      connection_result.each do |r|
+        if locate_config_value(:index)
+          index_num += 1
+          object_list << index_num.to_s
+        end
+
+        if locate_config_value(:fields)
+          locate_config_value(:fields).downcase.split(',').each { |n| object_list << ((r[("#{n}").strip]).to_s || 'N/A') }
+        else
+          object_list << r['name'].to_s
+          object_list << r['fingerprint'].to_s
+        end
+      end
+      puts ui.list(object_list, :uneven_columns_across, columns)
+      list_object_fields(connection_result) if locate_config_value(:fieldlist)
+    end
+
+  end
+end

--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -350,6 +350,15 @@ module CloudstackClient
       json = send_request(params)
       json['serviceoffering'] || []
     end
+    
+    def list_security_groups
+      params = {
+          'command' => 'listSecurityGroups'
+      }
+      json = send_request(params)
+      json['securitygroups'] || []
+    end
+    
 
     ##
     # Finds the template with the specified name.


### PR DESCRIPTION
This adds three functions in knife-cs:
knife cs keypair list
knife cs keypair create --name foobar
knife cs keypair delete --name foobar

Handy for Public clouds that only use keypair auth.
