### PR TITLE
No longer send network_ids when the --no-public-ip option is specified

### DIFF
--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -265,6 +265,7 @@ module KnifeCloudstack
           locate_config_value(:cloudstack_disk),
           locate_config_value(:cloudstack_zone),
           locate_config_value(:cloudstack_networks),
+          locate_config_value(:public_ip),
           params
       )
 

--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -175,7 +175,7 @@ module CloudstackClient
     ##
     # Deploys a new server using the specified parameters.
 
-    def create_server(host_name, service_name, template_name, disk_name=nil, zone_name=nil, network_names=[], extra_params)
+    def create_server(host_name, service_name, template_name, disk_name=nil, zone_name=nil, network_names=[], public_ip=nil, extra_params)
 
       if host_name then
         if get_server(host_name) then
@@ -242,9 +242,9 @@ module CloudstackClient
             'command' => 'deployVirtualMachine',
             'serviceOfferingId' => service['id'],
             'templateId' => template['id'],
-            'zoneId' => zone['id'],
-            'networkids' => network_ids.join(',')
+            'zoneId' => zone['id']
         }
+        params['networkids'] = network_ids.join(',') if public_ip
 
       elsif
 


### PR DESCRIPTION
This should fix #1

The code is almost the same as what @agoddard wrote in #20, but ready to be merged with current master.

The fix originally made by @agoddard works well for me in basic mode.
