### PR TITLE
Add dependencies badge to readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,7 @@
 = knife-cloudstack
 
+{<img src="https://gemnasium.com/dpnl87/knife-cloudstack.png" alt="Dependency Status" />}[https://gemnasium.com/dpnl87/knife-cloudstack]
+
 == DESCRIPTION:
 
 This is the Edmunds Knife plugin for CloudStack. This plugin gives Knife the ability to create, bootstrap and manage


### PR DESCRIPTION
Add a gem dependency check with https://gemnasium.com and display the badge on the readme file. This way we can show that the knife plugin has up-to-date dependencies.
