### PR TITLE
add support for add/remove of networks to vms

### DIFF
--- a/lib/chef/knife/cs_server_add_nic.rb
+++ b/lib/chef/knife/cs_server_add_nic.rb
@@ -1,0 +1,109 @@
+#
+# Author:: John E. Vincent (<lusis.org+github.com@gmail.com>)
+# Copyright:: Copyright (c) 2013 John E. Vincent
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/cs_base'
+require 'chef/knife/cs_baselist'
+
+module KnifeCloudstack
+  class CsServerAddNic < Chef::Knife
+
+    include Chef::Knife::KnifeCloudstackBase
+    include Chef::Knife::KnifeCloudstackBaseList
+
+    deps do
+      require 'knife-cloudstack/connection'
+      require 'chef/knife'
+      Chef::Knife.load_deps
+    end
+
+    banner "knife cs server add nic SERVERID NETWORKID (--ipaddress X.X.X.X)"
+
+    option :ipaddress,
+           :long => "--ipaddress IPADDRESS",
+           :description => "Attach with the specified IP",
+           :default => nil
+
+
+    def run
+      validate_base_options
+
+      @server_id, @network_id = name_args
+
+      if @network_id.nil? || @server_id.nil?
+        show_usage
+        ui.fatal("You must provide both a network id and a server id")
+        exit(1)
+      end
+
+      @ipaddr = locate_config_value(:ipaddress)
+
+      object_list = []
+      if locate_config_value(:fields)
+        locate_config_value(:fields).split(',').each { |n| object_list << ui.color(("#{n}").strip, :bold) }
+      else
+        object_list << ui.color('Server', :bold)
+        object_list << ui.color('Network', :bold)
+        object_list << ui.color('Type', :bold)
+        object_list << ui.color('Default', :bold)
+        object_list << ui.color('Address', :bold)
+        object_list << ui.color('Gateway', :bold)
+        object_list << ui.color('Netmask', :bold)
+        object_list << ui.color('ID', :bold)
+      end
+
+      columns = object_list.count
+
+      connection_result = connection.add_nic_to_vm(
+        @network_id,
+        @server_id,
+        @ipaddr
+      )
+
+      output_format(connection_result)
+
+      object_list << connection_result['name']
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      if connection_result['nic']
+        connection_result['nic'].each do |r|
+            if locate_config_value(:fields)
+              locate_config_value(:fields).downcase.split(',').each { |n| object_list << ((r[("#{n}").strip]).to_s || 'N/A') }
+            else
+              object_list << ''
+              object_list << r['networkname'].to_s
+              object_list << r['type'].to_s
+              object_list << (r['isdefault'] ? r['isdefault'].to_s : 'false')
+              object_list << (r['ipaddress'] || '')
+              object_list << (r['gateway'] || '')
+              object_list << (r['netmask'] || '')
+              object_list << (r['networkid'] || '')
+            end
+        end
+        puts ui.list(object_list, :uneven_columns_across, columns)
+        list_object_fields(connection_result) if locate_config_value(:fieldlist)
+      else
+        ui.error("No nics returned in response")
+      end
+    end
+  end
+end

--- a/lib/chef/knife/cs_server_remove_nic.rb
+++ b/lib/chef/knife/cs_server_remove_nic.rb
@@ -1,0 +1,101 @@
+#
+# Author:: John E. Vincent (<lusis.org+github.com@gmail.com>)
+# Copyright:: Copyright (c) 2013 John E. Vincent
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'chef/knife/cs_base'
+require 'chef/knife/cs_baselist'
+
+module KnifeCloudstack
+  class CsServerRemoveNic < Chef::Knife
+
+    include Chef::Knife::KnifeCloudstackBase
+    include Chef::Knife::KnifeCloudstackBaseList
+
+    deps do
+      require 'knife-cloudstack/connection'
+      require 'chef/knife'
+      Chef::Knife.load_deps
+    end
+
+    banner "knife cs server remove nic SERVERID NICID"
+
+
+    def run
+      validate_base_options
+
+      @server_id, @nic_id = name_args
+
+      if @server_id.nil? || @nic_id.nil?
+        show_usage
+        ui.fatal("You must provide both a nic id and a server id")
+        exit(1)
+      end
+
+
+      object_list = []
+      if locate_config_value(:fields)
+        locate_config_value(:fields).split(',').each { |n| object_list << ui.color(("#{n}").strip, :bold) }
+      else
+        object_list << ui.color('Server', :bold)
+        object_list << ui.color('Network', :bold)
+        object_list << ui.color('Type', :bold)
+        object_list << ui.color('Default', :bold)
+        object_list << ui.color('Address', :bold)
+        object_list << ui.color('Gateway', :bold)
+        object_list << ui.color('Netmask', :bold)
+        object_list << ui.color('ID', :bold)
+      end
+
+      columns = object_list.count
+
+      connection_result = connection.remove_nic_from_vm(
+        @nic_id,
+        @server_id
+      )
+
+      output_format(connection_result)
+
+      object_list << connection_result['name']
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      object_list << ''
+      if connection_result['nic']
+        connection_result['nic'].each do |r|
+            if locate_config_value(:fields)
+              locate_config_value(:fields).downcase.split(',').each { |n| object_list << ((r[("#{n}").strip]).to_s || 'N/A') }
+            else
+              object_list << ''
+              object_list << r['networkname'].to_s
+              object_list << r['type'].to_s
+              object_list << (r['isdefault'] ? r['isdefault'].to_s : 'false')
+              object_list << (r['ipaddress'] || '')
+              object_list << (r['gateway'] || '')
+              object_list << (r['netmask'] || '')
+              object_list << (r['networkid'] || '')
+            end
+        end
+        puts ui.list(object_list, :uneven_columns_across, columns)
+        list_object_fields(connection_result) if locate_config_value(:fieldlist)
+      else
+        ui.error("No nics returned in response")
+      end
+    end
+  end
+end

--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -612,6 +612,32 @@ module CloudstackClient
       nil
     end
 
+    def add_nic_to_vm(network_id, server_id, ipaddr=nil)
+      params = {
+        'command' => 'addNicToVirtualMachine',
+        'networkid' => network_id,
+        'virtualmachineid' => server_id,
+      }
+
+      unless ipaddr.nil?
+        params['ipaddress'] = ipaddr
+      end
+
+      json = send_async_request(params)
+      json['virtualmachine']
+    end
+
+    def remove_nic_from_vm(nic_id, server_id)
+      params = {
+        'command' => 'removeNicFromVirtualMachine',
+        'nicid' => nic_id,
+        'virtualmachineid' => server_id,
+      }
+
+      json = send_async_request(params)
+      json['virtualmachine']
+    end
+
     ##
     # Finds the default zone for your account.
 


### PR DESCRIPTION
this allows adding and removing of nics to vms. Really needs a `knife cs server listnics` to go along with it so folks can get the uuids of the nics for deletion. Both calls, however, work with uuids:

```
» knife cs server add nic 28d4f061-30ed-4589-835b-df7c279f7863 ec5f314d-0413-417c-9485-f0c9627a2e7d
..
Server         Network                Type      Default  Address       Gateway     Netmask        ID
i3-nrouter-02
               prod-isolated-network  Isolated  true     172.16.2.173  172.16.2.1  255.255.255.0  a0386da2-a472-41ef-a174-e2017facfd35
               trial-network          Isolated  false    172.16.3.217  172.16.3.1  255.255.255.0  ec5f314d-0413-417c-9485-f0c9627a2e7d
```

```
» knife cs server remove nic 28d4f061-30ed-4589-835b-df7c279f7863 2559b2c2-8f34-4ce5-9283-c805b96255ea
..
Server         Network                Type      Default  Address       Gateway     Netmask        ID
i3-nrouter-02
               prod-isolated-network  Isolated  true     172.16.2.173  172.16.2.1  255.255.255.0  a0386da2-a472-41ef-a174-e2017facfd35
```

```
» knife cs server add nic 28d4f061-30ed-4589-835b-df7c279f7863 ec5f314d-0413-417c-9485-f0c9627a2e7d --ipaddress 172.16.3.2
..
Server         Network                Type      Default  Address       Gateway     Netmask        ID
i3-nrouter-02
               prod-isolated-network  Isolated  true     172.16.2.173  172.16.2.1  255.255.255.0  a0386da2-a472-41ef-a174-e2017facfd35
               trial-network          Isolated  false    172.16.3.2    172.16.3.1  255.255.255.0  ec5f314d-0413-417c-9485-f0c9627a2e7d
```
