### PR TITLE
Fix list_object method calls by invalid typed parameters

### DIFF
--- a/lib/chef/knife/cs_firewallrule_create.rb
+++ b/lib/chef/knife/cs_firewallrule_create.rb
@@ -47,10 +47,8 @@ module KnifeCloudstack
       locate_config_value(:openfirewall) ? params['openfirewall'] = 'true' : params['openfirewall'] = 'false'
 
       # Lookup all server objects.
-      connection_result = connection.list_object(
-        "listVirtualMachines",
-        "virtualmachine"
-      )
+      params_for_list_object = { 'command' => 'listVirtualMachines' }
+      connection_result = connection.list_object(params_for_list_object, "virtualmachine")
 
       # Lookup the hostname in the connection result
       server = {}

--- a/lib/chef/knife/cs_forwardrule_create.rb
+++ b/lib/chef/knife/cs_forwardrule_create.rb
@@ -52,10 +52,8 @@ module KnifeCloudstack
       locate_config_value(:openfirewall) ? params['openfirewall'] = 'true' : params['openfirewall'] = 'false'
 
       # Lookup all server objects.
-      connection_result = connection.list_object(
-        "listVirtualMachines",
-        "virtualmachine"
-      )
+      params_for_list_object = {  'command' => 'listVirtualMachines' }
+      connection_result = connection.list_object(params_for_list_object, "virtualmachine")
 
       # Lookup the hostname in the connection result
       server = {}


### PR DESCRIPTION
list_object method requires hash object as 1st argument. But string objects "listVirtualMachines" are used within cs_firewallrule_create.rb and cs_forwardrule_create.rb.

Please fix it.
