### PR TITLE
disable sending of network ids

### DIFF
--- a/lib/knife-cloudstack/connection.rb
+++ b/lib/knife-cloudstack/connection.rb
@@ -236,8 +236,8 @@ module CloudstackClient
             'command' => 'deployVirtualMachine',
             'serviceOfferingId' => service['id'],
             'templateId' => template['id'],
-            'zoneId' => zone['id'],
-            'networkids' => network_ids.join(',')
+            'zoneId' => zone['id']
+#            'networkids' => network_ids.join(',')
         }
 
       else


### PR DESCRIPTION
disable sending of network ids, due to cs return ALL networks for 'listNetworks' request, not only for current account