### PR TITLE
Remove em-winrm dependency as it is deprecated

### DIFF
--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -50,7 +50,6 @@ module KnifeCloudstack
       require 'knife-cloudstack/connection'
       require 'winrm'
       require 'httpclient'
-      require 'em-winrm'
       Chef::Knife::Bootstrap.load_deps
     end
 


### PR DESCRIPTION
The functionality is merged into knife-windows.

See https://github.com/chef/em-winrm.

Please make a new release and publish to rubygems.