### PR TITLE
Set the passed secret file as a knife config

### DIFF
--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -137,7 +137,8 @@ module KnifeCloudstack
 
     option :secret_file,
            :long => "--secret-file SECRET_FILE",
-           :description => "The path to the file that contains the encryption key."
+           :description => "The path to the file that contains the encryption key.",
+           :proc => lambda { |secret_file| Chef::Config[:knife][:secret_file] = secret_file }
 
     option :secret,
            :long => "--secret SECRET",


### PR DESCRIPTION
This allows Chef to create the secret file on the boostrapped node.