### PR TITLE
Assign Security groups on server creation when passed

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -112,6 +112,11 @@ Firewall rules have the syntax <tt>PROTOCOL[:CIDR_LIST[:START_PORT[:END_PORT]]]<
 The default value of <tt>END_PORT</tt> is <tt>START_PORT</tt>, the default <tt>CIDR_LIST</tt> is '0.0.0.0/0'.
 For example, a rule to open firewall for port 80 to everyone would look like <tt>TCP::80</tt> and a rule to open ICMP to internal network would look like <tt>ICMP:10.0.0.0/8</tt>.
 
+==== Assign Security groups to a server
+The <tt>--security-groups</tt> option takes a comma separated list of security groups which are applied to the public ip address assigned to the current server.
+
+Pass a list of coma separated security groups (as UUIDs), for example: <tt>--security-groups f8fe00cf-f5c1-409d-8c7e-0d6bdcebe736,a7c4b500-a6ca-4258-8187-f160cd43a422</tt>
+
 === knife cs server delete
 
 Deletes an existing server in the currently configured CloudStack account.  <b>PLEASE NOTE</b> - this does not delete

--- a/lib/chef/knife/cs_server_create.rb
+++ b/lib/chef/knife/cs_server_create.rb
@@ -247,6 +247,10 @@ module KnifeCloudstack
         :description => "Add options to wget when installing chef-client",
         :proc        => Proc.new { |wo| Chef::Config[:knife][:bootstrap_wget_options] = wo }
 
+    option :security_groups,
+           :long => "--security-groups SECURITY_GROUPS",
+           :description => "Comma separated list of security rules, e.g. 'f8fe00cf-f5c1-409d-8c7e-0d6bdcebe736,a7c4b500-a6ca-4258-8187-f160cd43a422'"
+
     def run
       validate_base_options
 
@@ -291,6 +295,7 @@ module KnifeCloudstack
       params['displayname'] = if locate_config_value :set_display_name and locate_config_value :chef_node_name then locate_config_value :chef_node_name else hostname end
       params['ipaddress'] = locate_config_value(:ik_private_ip) if locate_config_value(:ik_private_ip)
       params['size'] = locate_config_value(:size) if locate_config_value(:size)
+      params['securitygroupids'] = locate_config_value(:security_groups) if locate_config_value(:security_groups)
 
       server = connection.create_server(
           hostname,


### PR DESCRIPTION
The switch is `--security-groups` and takes a coma separated list of UUIDs

We are using this so we don't have to pass a list of firewall rules on every server creation. It doesn't change anything when no security groups are passed